### PR TITLE
Novas funcionalidades: Mask::MAC, isMac(), isIp()

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Utils::mask('12345678901234', Mask::DOCUMENTO); //Output: 12.345.678/9012-34
 Utils::mask('31988710521', Mask::TELEFONE); //Output: (31)98871-0521
 Utils::mask('3188710521', Mask::TELEFONE); //Output: (31)8871-0521
 
+Utils::mask('a1b2c3d4e5f6', Mask::MAC); //Output: a1:b2:c3:d4:e5:f6
+
 Utils::unmask('31.030-080'); //Output: 31030080
 
 Utils::unaccents('Êita método bão sô!'); //Output: Eita metodo bao so!   
@@ -61,6 +63,13 @@ Utils::moeda('3500.22', 'US$', 2) //Output: US$ 3.500,22
 
 Utils::unmoeda('R$ 2.000,00') //Output: 2000   
 Utils::unmoeda('US$ 3.500,22') //Output: 3500.22
+
+Utils::isMac('a1b2c3d4e5f6') // Output: true
+Utils::isMac('a1:b2:c3:d4:e5:f6') // Output: true
+
+Utils::isIp('127.0.0') // Output: false
+Utils::isIp('127.0.0.1') // Output: true
+Utils::isIp('192.168.0.255') // Output: true
 ```
 
 

--- a/src/Mask.php
+++ b/src/Mask.php
@@ -9,5 +9,6 @@ abstract class Mask{
     const CPF = '###.###.###-##';
     const CNPJ = '##.###.###/####-##';
     const CEP = '##.###-###';
+    const MAC = '##:##:##:##:##:##';
 
 }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -52,6 +52,10 @@ class Utils {
         if ($qtd > strlen($txt)) {
             $txt = str_pad($txt, $qtd, "0", STR_PAD_LEFT);
         }
+        elseif ($qtd < strlen($txt)) 
+        {
+            return $txt;
+        }
 
         if ($txt <> '') {
             $string = str_replace(" ", "", $txt);
@@ -72,7 +76,7 @@ class Utils {
      * @return string (Texto sem a mascara)
      */
     public static function unmask($texto) {
-        return preg_replace('/[\-\|\(\)\/\. ]/', '', $texto);
+        return preg_replace('/[\-\|\(\)\/\.\: ]/', '', $texto);
     }
 
     /**
@@ -201,6 +205,27 @@ class Utils {
     public static function unmoeda($string = "", $simbolo = 'R$') {
         $string = str_replace('.', '', str_replace($simbolo, '', $string));
         return floatval(str_replace(',', '.', $string));
+    }
+
+    /**
+     * Metodo para verificar se um Endereço Mac é válido
+     *
+     * @param  string $mac
+     * @return boolean
+     */
+    public static function isMac($mac) {
+        $mac = self::mask(self::unmask($mac), Mask::MAC);
+        return (bool) filter_var($mac, FILTER_VALIDATE_MAC);
+    }
+
+    /**
+     * Metodo para verificar se um Endereço Ip é válido
+     *
+     * @param  string $ip
+     * @return boolean
+     */
+    public static function isIp($ip) {
+        return (bool) filter_var($ip, FILTER_VALIDATE_IP);
     }
 
 }

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -16,10 +16,13 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 
         $this->assertEquals('(31)3072-7066', Utils::mask('3130727066', Mask::TELEFONE));
         $this->assertEquals('(31)99503-7066', Utils::mask('31995037066', Mask::TELEFONE));
+
+        $this->assertEquals('a1:b2:c3:d4:e5:f6', Utils::mask('a1b2c3d4e5f6', Mask::MAC));
     }
 
     public function testUnmask() {
         $this->assertEquals('73258442398', Utils::unmask('732.584.423-98'));
+        $this->assertEquals('a1b2c3d4e5f6', Utils::unmask('a1:b2:c3:d4:e5:f6'));
     }
 
     public function testUnaccents() {
@@ -55,6 +58,19 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
     public function testUnmoeda() {
         $this->assertEquals(2000, Utils::unmoeda('R$ 2.000,00'));
         $this->assertEquals(3500.22, Utils::unmoeda('US$ 3.500,22', 'US$'));
+    }
+
+    public function testIsMac() {
+        $this->assertEquals(true, Utils::isMac('a1:b2:c3:d4:e5:f6'));
+        $this->assertEquals(true, Utils::isMac('a1b2c3d4e5f6'));
+        $this->assertEquals(true, Utils::isMac('a1-b2-c3-d4-e5-f6'));
+        $this->assertEquals(false, Utils::isMac('a1b2c3d4e5f6g7'));
+    }
+
+    public function testIsIp() {
+        $this->assertEquals(false, Utils::isIp('127.0.0'));
+        $this->assertEquals(true,  Utils::isIp('127.0.0.1'));
+        $this->assertEquals(true,  Utils::isIp('192.168.0.255'));
     }
 
 }


### PR DESCRIPTION
Adicionei algumas funcionalidades que precisei utilizar e acho que talvez possa ser útil a mais alguém:

Utils::mask($txt, Mask::MAC) // Aplica máscara MAC em um Endereço Mac
Utils::isMac($mac) // Metodo para verificar se um Endereço Mac é válido
Utils::isIp($ip) // Metodo para verificar se um Endereço Ip é válido

Acrescentei uma verificação no método mask() pra checar se o o comprimento da máscara é menor do que o comprimento do texto. Caso seja, é retornado $txt sem a máscara e assim não é retornado o erro "String offset cast occurred" (Linhas 55:58 do arquivo Utils.php).

Obrigado!
